### PR TITLE
noscript-Support für CSS ergänzt

### DIFF
--- a/lib/theme_assets.php
+++ b/lib/theme_assets.php
@@ -63,13 +63,19 @@ class theme_assets
         return $this;
     }
 
-    public function setCss(string $key, string $data, string $media = 'all', array $attributes = []): theme_assets
+    public function setCss(string $key, string $data, string $media = '', array $attributes = [], bool $noscript = false): theme_assets
     {
-        $attributes['media'] = $media;
+        // If the media attribute is not set, do not default to 'all', because it is considered render-blocking
+        // Even an empty media="" can be render-blocking, so we only set it if a media type is given
+        // https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources?hl=de
+        if($media !== '') {
+            $attributes['media'] = $media;
+        }
 
         $this->css[$key] = [
             'data' => $data,
             'attributes' => $attributes,
+            'noscript' => $noscript,
         ];
 
         return $this;
@@ -163,7 +169,7 @@ class theme_assets
 
         if (!$return) {
             foreach ($this->css as $css_key => $css) {
-                $return .= $this->getLinkTag($this->id.'--'.$css_key, $css['data'], $css['attributes'], $this->cache_buster);
+                $return .= $this->getLinkTag($this->id.'--'.$css_key, $css['data'], $css['attributes'], $this->cache_buster, $css['noscript'] ?? false);
             }
         }
 

--- a/lib/theme_assets_trait.php
+++ b/lib/theme_assets_trait.php
@@ -38,18 +38,22 @@ trait theme_assets_trait
      *
      * @return string
      */
-    private function getLinkTag(string $key, string $file, array $attributes, string $cache_buster = ''): string
+    private function getLinkTag(string $key, string $file, array $attributes, string $cache_buster = '', bool $noscript = false): string
     {
         if ($this->isAdmin()) {
             $attributes['data-key'] = 'style--'.$key;
         }
-
+        $noscript_tag = $noscript ? '<noscript><link rel="stylesheet" href="'.$this->stripDots($file).$this->getCacheBuster($file, $cache_buster).'"></noscript>' : '';
+        $onload = '';
+        if($noscript) {
+            $onload = ' onload="this.onload=null;this.rel=\'stylesheet\'"'; // rex_string::buildAttributes() bypass wegen Sanitizer der Hochkommata
+        }
         $attributes['href'] = $this->stripDots($file).$this->getCacheBuster($file, $cache_buster);
 
         $attributes['rel'] = $attributes['rel'] ?? 'stylesheet';
         $attributes['type'] = $attributes['type'] ?? 'text/css';
 
-        return '<link'.rex_string::buildAttributes($attributes).' />'.PHP_EOL;
+        return '<link'.rex_string::buildAttributes($attributes).$onload.' />'.$noscript_tag.PHP_EOL;
     }
 
     /**


### PR DESCRIPTION
Noscript für CSS ergänzt für render-blocking-assets, `media="all"` als default gestrichen, wegen best-practice.
https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources?hl=de

man kann nun wie folgt css einbinden:

`$assets->setCss('plyr', '/assets/addons/plyr/vendor/plyr/dist/plyr.css','', ['rel' => 'preload', 'as' => 'style'], true);`

daraus wird dann:

`<link rel="preload" as="style" href="/assets/addons/plyr/vendor/plyr/dist/plyr.css" type="text/css" onload="this.onload=null;this.rel='stylesheet'" /><noscript><link rel="stylesheet" href="/assets/addons/plyr/vendor/plyr/dist/plyr.css"></noscript>`

